### PR TITLE
Symlink support - use `fs.realpathSync(file)` inside `Writer`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function getTempFile (file) {
 }
 
 function Writer (file) {
-  this.file = file
+  this.file = fs.realpathSync(file)
   this.callbacks = []
   this.nextData = null
   this.nextCallbacks = []


### PR DESCRIPTION
Fixes #13 

This resolves the true file, thus allowing us to have symlinks without writing to them, but what they point to.

See also https://nodejs.org/docs/latest/api/fs.html#fs_fs_realpath_path_options_callback