### PR TITLE
fix: change tempfile name

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var writers = {}
 // Returns a temporary file
 // Example: for /some/file will return /some/.~file
 function getTempFile (file) {
-  return path.join(path.dirname(file), '.~' + path.basename(file))
+  return path.join(path.dirname(file), '.tmp__' + path.basename(file))
 }
 
 function Writer (file) {


### PR DESCRIPTION
```
{ [Error: EINVAL: invalid argument, rename '/root/.config/.cloudbase/.~auth.json' -> '/root/.config/.cloudbase/auth.json']
  errno: -22,
  code: 'EINVAL',
  syscall: 'rename',
  path: '/root/.config/.cloudbase/.~auth.json',
  dest: '/root/.config/.cloudbase/auth.json' }
```
I have an issue when i use this pack in an special linux system. `fs.rename` run fail, i guess the filename has some problem. So i change between code 
```
function getTempFile (file) {
  return path.join(path.dirname(file), '.~' + path.basename(file))
}
```
to
```
function getTempFile (file) {
  return path.join(path.dirname(file), '.temp__' + path.basename(file))
}
```
it works fine. maybe filename has "~" not compatible in some unix