### PR TITLE
chore: fix benchmark script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,18 @@ async function save() {
 
 ```
 Write 1KB data to the same file x 1000
-  fs   : 68.464ms
-  steno: 0.578ms
+  fs (sequential): 229.574ms
+  steno (sequential): 250.186ms
+
+  fs (parallel): 78.812ms
+  steno (parallel): 1.332ms
 
 Write 1MB data to the same file x 1000
-  fs   : 2.166s
-  steno: 1.153ms
+  fs (sequential): 4.707s
+  steno (sequential): 4.303s
+
+  fs (parallel): 1.031s
+  steno (parallel): 9.245ms
 ```
 
 ## License

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -11,19 +11,29 @@ async function benchmark(data: string, msg: string): Promise<void> {
 
   // console.log(`temp dir: ${dir}`)
   console.log(msg)
-  console.time('  fs   ')
+  console.time('  fs (sequential)')
   for (let i = 0; i < 1000; i++) {
     await writeFile(fsFile, data)
   }
-  console.timeEnd('  fs   ')
+  console.timeEnd('  fs (sequential)')
 
-  console.time('  steno')
+  console.time('  steno (sequential)')
   for (let i = 0; i < 1000; i++) {
     // eslint-disable-next-line
-    steno.write(data)
+    await steno.write(data)
   }
-  console.timeEnd('  steno')
+  console.timeEnd('  steno (sequential)')
   console.log()
+
+  console.time('  fs (parallel)')
+  await Promise.all([...Array(1000).keys()].map(() => writeFile(fsFile, data)))
+  console.timeEnd('  fs (parallel)')
+
+  console.time('  steno (parallel)')
+  await Promise.all([...Array(1000).keys()].map(() => steno.write(data)))
+  console.timeEnd('  steno (parallel)')
+  console.log()
+
 }
 
 async function run(): Promise<void> {


### PR DESCRIPTION
Update benchmark script to test two methods in same conditions (awaiting on `steno.write` promise). Also testing with sequential and parallel:

```
Write 1KB data to the same file x 1000
  fs (sequential): 229.574ms
  steno (sequential): 250.186ms

  fs (parallel): 78.812ms
  steno (parallel): 1.332ms

Write 1MB data to the same file x 1000
  fs (sequential): 4.707s
  steno (sequential): 4.303s

  fs (parallel): 1.031s
  steno (parallel): 9.245ms
```

I think the result depends on more variables operating system, filesystem driver, storage type, and filesystem-level caching (we are writing same zero-filled buffer) but this change makes results more realistic. (perf improvement is in parallel condition)