### PR TITLE
chore: npm run lint -- --fix

### DIFF
--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -6,55 +6,42 @@ import path from 'path'
 import { Writer } from './index.js'
 
 async function benchmark(data: string, msg: string): Promise<void> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), 'steno-'))
-  const fsLabel = '  fs     '
-  const stenoLabel = '  steno  '
-  const fsFile = path.join(dir, 'fs.txt')
-  const stenoFile = path.join(dir, 'steno.txt')
-  const steno = new Writer(stenoFile)
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'steno-'))
+    const fsLabel = '  fs     '
+    const stenoLabel = '  steno  '
+    const fsFile = path.join(dir, 'fs.txt')
+    const stenoFile = path.join(dir, 'steno.txt')
+    const steno = new Writer(stenoFile)
 
-  // console.log(`temp dir: ${dir}`)
-  console.log(msg)
-  console.log()
+    // console.log(`temp dir: ${dir}`)
+    console.log(msg)
+    console.log()
 
-  console.time(fsLabel)
-  // To avoid race condition issues, we need to wait
-  // between write when using fs only
-  for (let i = 0; i < 1000; i++) {
-    await writeFile(fsFile, `${data}${i}`)
-  }
-  console.timeEnd(fsLabel)
+    console.time(fsLabel)
+    // To avoid race condition issues, we need to wait
+    // between write when using fs only
+    for (let i = 0; i < 1000; i++) {
+        await writeFile(fsFile, `${data}${i}`)
+    }
+    console.timeEnd(fsLabel)
 
-  console.time(stenoLabel)
-  // Steno can be run in parallel
-  await Promise.all(
-    [...Array(1000).keys()].map((_, i) => steno.write(`${data}${i}`)),
-  )
-  console.timeEnd(stenoLabel)
+    console.time(stenoLabel)
+    // Steno can be run in parallel
+    await Promise.all([...Array(1000).keys()].map((_, i) => steno.write(`${data}${i}`)))
+    console.timeEnd(stenoLabel)
 
-  // Testing that the end result is the same
-  console.log()
-  console.log(
-    '  fs.txt = steno.txt',
-    readFileSync(fsFile, 'utf-8') === readFileSync(stenoFile, 'utf-8')
-      ? '✓'
-      : '✗',
-  )
-  console.log()
-  console.log()
+    // Testing that the end result is the same
+    console.log()
+    console.log('  fs.txt = steno.txt', readFileSync(fsFile, 'utf-8') === readFileSync(stenoFile, 'utf-8') ? '✓' : '✗')
+    console.log()
+    console.log()
 }
 
 async function run(): Promise<void> {
-  const KB = 1024
-  const MB = 1048576
-  await benchmark(
-    Buffer.alloc(KB, 'x').toString(),
-    'Write 1KB data to the same file x 1000',
-  )
-  await benchmark(
-    Buffer.alloc(MB, 'x').toString(),
-    'Write 1MB data to the same file x 1000',
-  )
+    const KB = 1024
+    const MB = 1048576
+    await benchmark(Buffer.alloc(KB, 'x').toString(), 'Write 1KB data to the same file x 1000')
+    await benchmark(Buffer.alloc(MB, 'x').toString(), 'Write 1MB data to the same file x 1000')
 }
 
 void run()

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,76 +6,76 @@ import { fileURLToPath } from 'node:url'
 // Returns a temporary file
 // Example: for /some/file will return /some/.file.tmp
 function getTempFilename(file: PathLike): string {
-  const f = file instanceof URL ? fileURLToPath(file) : file.toString()
-  return join(dirname(f), `.${basename(f)}.tmp`)
+    const f = file instanceof URL ? fileURLToPath(file) : file.toString()
+    return join(dirname(f), `.${basename(f)}.tmp`)
 }
 
 type Resolve = () => void
 type Reject = (error: Error) => void
 
 export class Writer {
-  #filename: PathLike
-  #tempFilename: PathLike
-  #locked = false
-  #prev: [Resolve, Reject] | null = null
-  #next: [Resolve, Reject] | null = null
-  #nextPromise: Promise<void> | null = null
-  #nextData: string | null = null
+    #filename: PathLike
+    #tempFilename: PathLike
+    #locked = false
+    #prev: [Resolve, Reject] | null = null
+    #next: [Resolve, Reject] | null = null
+    #nextPromise: Promise<void> | null = null
+    #nextData: string | null = null
 
-  // File is locked, add data for later
-  #add(data: string): Promise<void> {
-    // Only keep most recent data
-    this.#nextData = data
+    // File is locked, add data for later
+    #add(data: string): Promise<void> {
+        // Only keep most recent data
+        this.#nextData = data
 
-    // Create a singleton promise to resolve all next promises once next data is written
-    this.#nextPromise ||= new Promise((resolve, reject) => {
-      this.#next = [resolve, reject]
-    })
+        // Create a singleton promise to resolve all next promises once next data is written
+        this.#nextPromise ||= new Promise((resolve, reject) => {
+            this.#next = [resolve, reject]
+        })
 
-    // Return a promise that will resolve at the same time as next promise
-    return new Promise((resolve, reject) => {
-      this.#nextPromise?.then(resolve).catch(reject)
-    })
-  }
-
-  // File isn't locked, write data
-  async #write(data: string): Promise<void> {
-    // Lock file
-    this.#locked = true
-    try {
-      // Atomic write
-      await writeFile(this.#tempFilename, data, 'utf-8')
-      await rename(this.#tempFilename, this.#filename)
-
-      // Call resolve
-      this.#prev?.[0]()
-    } catch (err) {
-      // Call reject
-      if (err instanceof Error) {
-        this.#prev?.[1](err)
-      }
-      throw err
-    } finally {
-      // Unlock file
-      this.#locked = false
-
-      this.#prev = this.#next
-      this.#next = this.#nextPromise = null
-
-      if (this.#nextData !== null) {
-        const nextData = this.#nextData
-        this.#nextData = null
-        await this.write(nextData)
-      }
+        // Return a promise that will resolve at the same time as next promise
+        return new Promise((resolve, reject) => {
+            this.#nextPromise?.then(resolve).catch(reject)
+        })
     }
-  }
 
-  constructor(filename: PathLike) {
-    this.#filename = filename
-    this.#tempFilename = getTempFilename(filename)
-  }
+    // File isn't locked, write data
+    async #write(data: string): Promise<void> {
+        // Lock file
+        this.#locked = true
+        try {
+            // Atomic write
+            await writeFile(this.#tempFilename, data, 'utf-8')
+            await rename(this.#tempFilename, this.#filename)
 
-  async write(data: string): Promise<void> {
-    return this.#locked ? this.#add(data) : this.#write(data)
-  }
+            // Call resolve
+            this.#prev?.[0]()
+        } catch (err) {
+            // Call reject
+            if (err instanceof Error) {
+                this.#prev?.[1](err)
+            }
+            throw err
+        } finally {
+            // Unlock file
+            this.#locked = false
+
+            this.#prev = this.#next
+            this.#next = this.#nextPromise = null
+
+            if (this.#nextData !== null) {
+                const nextData = this.#nextData
+                this.#nextData = null
+                await this.write(nextData)
+            }
+        }
+    }
+
+    constructor(filename: PathLike) {
+        this.#filename = filename
+        this.#tempFilename = getTempFilename(filename)
+    }
+
+    async write(data: string): Promise<void> {
+        return this.#locked ? this.#add(data) : this.#write(data)
+    }
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -3,27 +3,28 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import url from 'node:url'
+
 import { Writer } from './index.js'
 
 export async function testSteno(): Promise<void> {
-  const max = 1000
+    const max = 1000
 
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'steno-test-'))
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'steno-test-'))
 
-  const file = path.join(dir, 'file.txt')
-  const fileURL = url.pathToFileURL(path.join(dir, 'fileURL.txt'))
+    const file = path.join(dir, 'file.txt')
+    const fileURL = url.pathToFileURL(path.join(dir, 'fileURL.txt'))
 
-  for (const f of [file, fileURL]) {
-    const writer = new Writer(f)
-    const promises = []
+    for (const f of [file, fileURL]) {
+        const writer = new Writer(f)
+        const promises = []
 
-    // Test race condition
-    for (let i = 1; i <= max; ++i) {
-      promises.push(writer.write(String(i)))
+        // Test race condition
+        for (let i = 1; i <= max; ++i) {
+            promises.push(writer.write(String(i)))
+        }
+
+        // All promises should resolve
+        await Promise.all(promises)
+        equal(parseInt(fs.readFileSync(file, 'utf-8')), max)
     }
-
-    // All promises should resolve
-    await Promise.all(promises)
-    equal(parseInt(fs.readFileSync(file, 'utf-8')), max)
-  }
 }


### PR DESCRIPTION
To reduce the diff noise of https://github.com/typicode/steno/pull/32, this PR can be merged first to resolve lint errors.

`lint` should really be added to the husky pre-commit hook, or the rules updated if these are no longer followed.